### PR TITLE
Fix: Remove explicit Referer header setting in XHR

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@
 
 通过这种方式，可以相对容易地扩展插件功能以支持更多网站，而无需对核心逻辑进行大量修改。
 
+## Changelog
+- **v1.0.1 (Internal Update)**
+  - Fixed an issue where explicitly setting the 'Referer' header for image download requests was causing a console error. This header is no longer set, allowing the browser to handle it automatically, which resolves the error and maintains functionality.
+
 ## 注意事项
 
 - 本插件仅供学习和研究使用。

--- a/content.js
+++ b/content.js
@@ -117,7 +117,6 @@ function downloadImageWithoutWatermark(img, siteId) { // siteId is available if 
   
   // 添加必要的请求头
   xhr.setRequestHeader('Accept', 'image/webp,image/apng,image/*,*/*;q=0.8');
-  xhr.setRequestHeader('Referer', window.location.href);
   
   xhr.onload = function() {
     if (xhr.status === 200) {


### PR DESCRIPTION
Removes the line `xhr.setRequestHeader('Referer', window.location.href);` from `content.js`. This was causing a "Refused to set unsafe header 'Referer'" error in the console, as 'Referer' is a browser-managed header.

The browser automatically sets the Referer header correctly for XHR requests originating from content scripts, so this change resolves the error without affecting the intended behavior.

Updated README.md with a changelog note for this fix.